### PR TITLE
Add high-level architecture documentation for NoTuMa "scaffold anew"

### DIFF
--- a/docs/architecture/api_specification.md
+++ b/docs/architecture/api_specification.md
@@ -1,0 +1,65 @@
+# API Specification
+
+The NoTuMa API is a RESTful service built with FastAPI. It provides the endpoints for narrative analysis, image generation, and manga composition.
+
+## Endpoint Overview
+
+### 1. Ingestion & Narrative Analysis
+
+#### POST /api/v1/ingest/upload
+Uploads a novel file and returns the chapter/scene segmentation.
+-   **Body:** `multipart/form-data` (file: File)
+-   **Returns:** `{ "projectId": String, "chapters": [{ "id": String, "title": String, "wordCount": Int }] }`
+
+#### GET /api/v1/narrative/chapter/{chapterId}
+Fetches a detailed analysis of a chapter, including scenes and characters.
+-   **Returns:** `{ "scenes": [{ "id": String, "text": String, "dialogue": [{ "characterId": String, "text": String }] }], "characters": [{ "id": String, "name": String, "traits": String[] }] }`
+
+#### POST /api/v1/narrative/character/profile
+Updates or creates a character profile with visual traits.
+-   **Body:** `{ "projectId": String, "name": String, "traits": String[], "visualRefUrl": String? }`
+
+### 2. Image Generation & Model Hub
+
+#### POST /api/v1/image/generate
+Enqueues a task to generate an image panel for a specific scene.
+-   **Body:** `{ "sceneId": String, "prompt": String, "styleProfileId": String?, "provider": String? }`
+-   **Returns:** `{ "taskId": String, "status": "pending" | "processing" | "completed" }`
+
+#### GET /api/v1/image/status/{taskId}
+Checks the status of a generation task.
+-   **Returns:** `{ "taskId": String, "status": "completed", "imageUrl": String? }`
+
+#### GET /api/v1/model-hub/providers
+Returns a list of available AI providers and their configuration requirements (e.g., BYOK).
+-   **Returns:** `[{ "id": String, "name": String, "requiresApiKey": Boolean, "capabilities": String[] }]`
+
+### 3. Composition & Canvas Editor
+
+#### GET /api/v1/composition/page/{pageId}
+Fetches the layout data for a manga page.
+-   **Returns:** `{ "pageId": String, "layout": Json, "imageUrl": String? }`
+
+#### POST /api/v1/composition/page/save
+Saves the current canvas layout for a page.
+-   **Body:** `{ "pageId": String, "layout": Json }`
+
+#### POST /api/v1/composition/page/render
+Renders a high-resolution version of the manga page based on the current layout.
+-   **Body:** `{ "pageId": String }`
+-   **Returns:** `{ "taskId": String }`
+
+### 4. Project Management & Export
+
+#### GET /api/v1/project/{projectId}
+Fetches all metadata and assets for a project.
+-   **Returns:** `{ "id": String, "title": String, "chapters": Chapter[], "characters": Character[] }`
+
+#### POST /api/v1/project/export
+Enqueues a task to export a project or chapter in the requested format (PDF, CBZ, EPUB).
+-   **Body:** `{ "projectId": String, "chapterId": String?, "format": "pdf" | "cbz" | "epub" }`
+-   **Returns:** `{ "taskId": String }`
+
+#### GET /api/v1/project/export/{taskId}
+Checks the status and returns the download link for an export.
+-   **Returns:** `{ "taskId": String, "status": "completed", "downloadUrl": String? }`

--- a/docs/architecture/data_model.md
+++ b/docs/architecture/data_model.md
@@ -1,0 +1,133 @@
+# Data Model
+
+NoTuMa uses a relational database (PostgreSQL) and S3-compatible object storage to manage its persistent data. The following documentation outlines the data schema and storage strategy.
+
+## Entity Relationship Diagram (ERD)
+
+The relational schema is centered around users, projects, chapters, and the visual assets that make up a manga.
+
+```prisma
+// Using Prisma schema syntax as a representation
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String    @id @default(uuid())
+  email     String    @unique
+  name      String?
+  projects  Project[]
+  apiKey    String?   // For BYOK features
+  createdAt DateTime  @default(now())
+}
+
+model Project {
+  id          String      @id @default(uuid())
+  title       String
+  description String?
+  userId      String
+  user        User        @relation(fields: [userId], references: [id])
+  chapters    Chapter[]
+  characters  Character[]
+  styleId     String?
+  style       StyleProfile? @relation(fields: [styleId], references: [id])
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
+}
+
+model Chapter {
+  id        String   @id @default(uuid())
+  title     String
+  order     Int
+  projectId String
+  project   Project  @relation(fields: [projectId], references: [id])
+  scenes    Scene[]
+  pages     Page[]
+  content   String   // Raw text of the chapter
+  createdAt DateTime @default(now())
+}
+
+model Scene {
+  id          String      @id @default(uuid())
+  order       Int
+  chapterId   String
+  chapter     Chapter     @relation(fields: [chapterId], references: [id])
+  text        String
+  description String?     // Generated prompt description
+  dialogues   Dialogue[]
+  panels      Panel[]
+  createdAt   DateTime    @default(now())
+}
+
+model Character {
+  id           String   @id @default(uuid())
+  name         String
+  description  String?
+  traits       String[] // Physical traits (hair color, eye color, etc.)
+  projectId    String
+  project      Project  @relation(fields: [projectId], references: [id])
+  visualRefUrl String?  // Link to a reference image in S3
+  loraId       String?  // Associated LoRA ID for consistency
+  createdAt    DateTime @default(now())
+}
+
+model Dialogue {
+  id          String    @id @default(uuid())
+  characterId String?
+  character   Character? @relation(fields: [characterId], references: [id])
+  sceneId     String
+  scene       Scene      @relation(fields: [sceneId], references: [id])
+  text        String
+  order       Int
+}
+
+model Page {
+  id        String   @id @default(uuid())
+  order     Int
+  chapterId String
+  chapter   Chapter  @relation(fields: [chapterId], references: [id])
+  layout    Json     // Canvas layout data (panel positions, bubbles)
+  imageUrl  String?  // Rendered page image URL in S3
+  createdAt DateTime @default(now())
+}
+
+model Panel {
+  id       String @id @default(uuid())
+  sceneId  String
+  scene    Scene  @relation(fields: [sceneId], references: [id])
+  imageUrl String // Generated image URL in S3
+  prompt   String
+  style    Json?  // Style parameters used
+}
+
+model StyleProfile {
+  id              String   @id @default(uuid())
+  name            String
+  sourceUrl       String?  // MangaDex or reference link
+  features        Json     // Extracted style features (color, line weight)
+  projects        Project[]
+}
+```
+
+## Storage Strategy
+
+Assets are stored in S3-compatible object storage (Cloudflare R2 or AWS S3) with the following directory structure:
+
+```
+/notuma-assets
+  /uploads
+    /{projectId}/{chapterId}/raw_novel.txt
+  /characters
+    /{projectId}/{characterId}/{characterId}_ref.png
+  /generated
+    /{projectId}/{chapterId}/{sceneId}/panel_{panelId}.png
+  /exports
+    /{projectId}/{chapterId}/chapter_{chapterId}.pdf
+    /{projectId}/{chapterId}/chapter_{chapterId}.cbz
+    /{projectId}/{chapterId}/chapter_{chapterId}.epub
+```
+
+-   **Public Access:** Generated images and exports are served via a CDN or a signed URL for temporary access.
+-   **Versioning:** S3 versioning may be enabled for critical assets like raw novel uploads.

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -1,0 +1,50 @@
+# System Overview
+
+NoTuMa (Novel To Manga) is designed as a distributed, high-performance system for transforming literary works into visual manga and manhwa. The architecture prioritizes scalability, modularity, and a professional-grade user experience.
+
+## High-Level Architecture
+
+The system is composed of several key components:
+
+1.  **Frontend (Next.js/React):** A responsive web application built with Next.js (App Router), Tailwind CSS, and Lucide React. It provides the interactive canvas for manga composition, project management, and a narrative editor.
+2.  **Backend (FastAPI):** A high-performance Python-based API server that handles business logic, narrative analysis, and orchestrates the AI image generation workflow.
+3.  **Database (PostgreSQL):** A relational database for persisting user projects, chapters, scenes, character profiles, and metadata.
+4.  **Task Queue (Celery + Redis):** A distributed task queue for asynchronous processing of long-running tasks, primarily AI image generation and complex NLP analysis.
+5.  **Storage (Cloudflare R2/AWS S3):** Scalable object storage for uploaded novels, generated images, and final manga exports.
+
+## Component Interaction
+
+The following Mermaid diagram illustrates the flow of data through the system:
+
+```mermaid
+graph TD
+    User((User)) -->|Uploads Novel| Frontend[Next.js Frontend]
+    Frontend -->|POST /upload| Backend[FastAPI Backend]
+    Backend -->|Saves Assets| Storage[S3-Compatible Storage]
+    Backend -->|Stores Metadata| DB[(PostgreSQL)]
+
+    Backend -->|Enqueues Task| Redis[Redis Queue]
+    Redis -->|Processes Job| Worker[Celery Worker]
+    Worker -->|NLP Analysis| LLM[LLM/NLP Engine]
+    Worker -->|Image Gen| ModelHub[AI Model Hub]
+
+    ModelHub -->|API Request| ExternalAI[External AI Providers]
+    ExternalAI -->|Returns Image| ModelHub
+
+    ModelHub -->|Saves Result| Storage
+    Worker -->|Updates Status| DB
+
+    Frontend -->|Polls Status| Backend
+    Backend -->|Fetches Data| DB
+    Backend -->|Retrieves Image| Storage
+    Backend -->|Returns Data| Frontend
+```
+
+## Core Workflow
+
+1.  **Ingestion:** The user uploads a novel in various formats (EPUB, DOCX, TXT). The system parses and segments the text into chapters and scenes.
+2.  **Narrative Analysis:** The system uses NLP and LLMs to extract characters, physical traits, relationships, and dialogue mapping.
+3.  **Character Management:** Users can define and persist character profiles (physical descriptions, visual references) to ensure consistency.
+4.  **Image Generation:** The "Model Hub" handles requests to various AI providers, using prompt engineering and techniques like LoRAs/IP-Adapter for consistent art styles.
+5.  **Composition:** Users use an interactive canvas to arrange generated panels, add speech bubbles, and apply manga-style effects (screentones, speed lines).
+6.  **Export:** The system generates high-resolution outputs in formats like PNG, PDF, CBZ, and Fixed-Layout EPUB.

--- a/docs/architecture/technical_deep_dives.md
+++ b/docs/architecture/technical_deep_dives.md
@@ -1,0 +1,48 @@
+# Technical Deep Dives
+
+This document provides more detailed information on key components and processes within NoTuMa.
+
+## 1. NLP Pipeline for Narrative Analysis
+
+NoTuMa's narrative engine transitions from simple heuristics to more sophisticated, context-aware analysis.
+
+### Character & Dialogue Extraction
+1.  **Preprocessing:** Text is cleaned, normalized, and segmented into chapters.
+2.  **NER (Named Entity Recognition):** The engine uses advanced NLP libraries (like Spacy or specialized LLM-based extraction) to identify character names and physical traits.
+3.  **Trait Synthesis:** Extracted physical traits are synthesized into character profiles.
+4.  **Dialogue Attribution:** Dialogue is attributed to specific characters using context-aware mapping, tracking the "speaker" throughout a scene or chapter.
+5.  **Scene Breakdown:** Chapters are segmented into narrative scenes based on character presence, location changes, and dialogue density.
+
+## 2. Model Hub & Image Generation
+
+The "Model Hub" is a modular interface for managing image generation requests across multiple providers.
+
+### Architecture
+-   **Provider Interface:** A standardized interface for different AI providers (Stability, OpenAI, NanoBanana, Replicate, Pollinations).
+-   **Prompt Orchestrator:** Generates optimal prompts for each provider, incorporating character profiles, style parameters, and scene descriptions.
+-   **BYOK (Bring Your Own Key):** Users can provide their own API keys for specific providers (e.g., NanoBanana) to manage costs and access specialized models.
+-   **Style Transfer & Consistency:**
+    -   **Style Profiles:** Extracted from MangaDex links, these profiles include parameters like color palette, line weight, and screentone density.
+    -   **Character Consistency:** Uses techniques like LoRAs (Low-Rank Adaptation) and IP-Adapter to maintain character visual consistency across different panels.
+
+## 3. Composition Engine (Canvas-Based Editor)
+
+The Composition Engine allows for interactive layout and arrangement of manga panels and speech bubbles.
+
+### Client-Side Editor
+-   **Framework:** Built using a canvas library like **Fabric.js** or **Konva.js**.
+-   **Panel Management:** Support for dragging, resizing, and layering panels, including diagonal and overlapping layouts.
+-   **Speech Bubbles:** Dynamic speech bubbles with customizable shapes, tails, and manga-style fonts.
+-   **Real-time Preview:** Users can preview the final composition in real-time.
+
+### Server-Side Rendering (SSR)
+-   **Pillow (PIL):** Used on the backend for high-resolution rendering and export of the final composition, ensuring consistency with the client-side preview.
+-   **Manga-Style Effects:** Post-processing layers for screentones, speed lines, and manga textures are applied during the rendering process.
+
+## 4. Export Pipeline
+
+The export pipeline is a separate worker task responsible for packaging the final manga into various professional formats.
+
+-   **CBZ (Comic Book Archive):** A collection of high-resolution PNG/JPEG files in a ZIP archive.
+-   **PDF:** A multi-page PDF document containing the rendered manga pages.
+-   **Fixed-Layout EPUB:** A specialized EPUB format designed for professional digital e-readers, ensuring a consistent visual experience.


### PR DESCRIPTION
This PR adds a comprehensive set of high-level architectural documents for the proposed "scaffold anew" state of the NoTuMa (Novel To Manga) project. 

Key documents added:
- `docs/architecture/system_overview.md`: High-level component breakdown and Mermaid diagram.
- `docs/architecture/data_model.md`: Relational schema (Prisma) and storage strategy.
- `docs/architecture/api_specification.md`: RESTful endpoint definitions.
- `docs/architecture/technical_deep_dives.md`: Detailed views on NLP, Model Hub, and Composition Engine.

This documentation serves as a blueprint for the project's transition from its current Flask-based prototype to a modern, scalable architecture.

---
*PR created automatically by Jules for task [16559938462665734300](https://jules.google.com/task/16559938462665734300) started by @Maverick-D-Aece*